### PR TITLE
Several fixes for the alpaka implementation of FCS-GPU

### DIFF
--- a/FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/AlpakaDefs.h
+++ b/FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/AlpakaDefs.h
@@ -23,9 +23,9 @@ namespace alpaka {
 #elif defined(ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED)
     using FccDefaultAcc = alpaka::AccCpuTbbBlocks<TDim, TIdx>;
 #elif defined(ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED)
-    using ExampleDefaultAcc = alpaka::AccCpuThreads<TDim, TIdx>;
+    using FccDefaultAcc = alpaka::AccCpuThreads<TDim, TIdx>;
 #elif defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
-    using ExampleDefaultAcc = alpaka::AccCpuSerial<TDim, TIdx>;
+    using FccDefaultAcc = alpaka::AccCpuSerial<TDim, TIdx>;
 #else
     class FccDefaultAcc;
 #   warning "No supported backend selected for default Alpaka accelerator"

--- a/FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/HostDevDef.h
+++ b/FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/HostDevDef.h
@@ -7,11 +7,6 @@
 #  define __DEVICE__  KOKKOS_INLINE_FUNCTION
 #  define __HOST__
 #  define __HOSTDEV__ KOKKOS_INLINE_FUNCTION
-/* #elif defined (USE_ALPAKA) */
-/* #  include <alpaka/alpaka.hpp> */
-/* #  define __DEVICE__ ALPAKA_FN_ACC */
-/* #  define __HOST__   ALPAKA_FN_HOST */
-/* #  define __HOSTDEV__ ALPAKA_FN_HOST_ACC */
 #elif defined (USE_STDPAR)
 #  if defined (_NVHPC_STDPAR_NONE)
 #    define __DEVICE__
@@ -24,6 +19,11 @@
 #  define __DEVICE__ __device__
 #  define __HOST__   __host__
 #  define __HOSTDEV__ __host__ __device__
+#elif defined (USE_ALPAKA) && defined (ALPAKA_LOCAL)
+#  include <alpaka/alpaka.hpp>
+#  define __DEVICE__ ALPAKA_FN_ACC
+#  define __HOST__   ALPAKA_FN_HOST
+#  define __HOSTDEV__ ALPAKA_FN_HOST_ACC
 #elif defined (__GNUC__)
 #  define __DEVICE__
 #  define __HOST__

--- a/FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/Rand4Hits.h
+++ b/FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/Rand4Hits.h
@@ -126,9 +126,9 @@ private:
 #endif
 
 #ifdef USE_ALPAKA
+  QueueAcc m_queue;
   BufAcc m_bufAcc;
   BufAccEngine m_bufAccEngine;
-  QueueAcc m_queue;
   CellsEnergy m_cellsEnergy;
   CellE m_cellE;
   CellCtT m_cT;

--- a/FastCaloSimAnalyzer/FastCaloGpu/src/CMakeLists.txt
+++ b/FastCaloSimAnalyzer/FastCaloGpu/src/CMakeLists.txt
@@ -92,6 +92,13 @@ if(USE_ATOMIC_ADD)
   target_compile_definitions(${FastCaloGpu_LIB} PRIVATE -DUSE_ATOMICADD )
 endif()
 
+# This is a hack to prevent the exposure of alpaka definitions outside
+# FastCaloGpu library via HostDevDef.h
+if(USE_ALPAKA)
+  target_compile_definitions(${FastCaloGpu_LIB} PRIVATE -DALPAKA_LOCAL )
+endif()
+
+
 # Install library
 install(TARGETS ${FastCaloGpu_LIB}
   DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/FastCaloSimAnalyzer/FastCaloGpu/src/CaloGpuGeneral_al.cxx
+++ b/FastCaloSimAnalyzer/FastCaloGpu/src/CaloGpuGeneral_al.cxx
@@ -42,7 +42,7 @@ namespace CaloGpuGeneral_al {
 				  ) const -> void
     {
       auto const idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0];
-      if(idx < nhits) {
+      if(idx < (unsigned)nhits) {
 	Hit hit;
 	hit.E() = E;
 	
@@ -180,7 +180,7 @@ namespace CaloGpuGeneral_al {
 #ifdef DUMP_HITCELLS
     std::cout << "hitcells: " << args.ct << "  nhits: " << nhits << "  E: " << E << "\n";
     std::map<unsigned int,float> cm;
-    for (int i=0; i<args.ct; ++i) {
+    for (unsigned i=0; i<args.ct; ++i) {
       cm[args.hitcells_E_h[i].cellid] = args.hitcells_E_h[i].energy;
     }
     for (auto &em: cm) {

--- a/FastCaloSimAnalyzer/FastCaloGpu/src/CaloGpuGeneral_fnc.cxx
+++ b/FastCaloSimAnalyzer/FastCaloGpu/src/CaloGpuGeneral_fnc.cxx
@@ -114,7 +114,7 @@ namespace CaloGpuGeneral_fnc {
   /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
   __DEVICE__ void rnd_to_fct2d( float& valuex, float& valuey, float rnd0, float rnd1, FH2D* hf2d,
-                                unsigned long i, float ene) {
+                                unsigned long /*i*/, float /*ene*/) {
 
     int    nbinsx        = ( *hf2d ).nbinsx;
     int    nbinsy        = ( *hf2d ).nbinsy;
@@ -245,9 +245,9 @@ namespace CaloGpuGeneral_fnc {
 
   /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifdef USE_ALPAKA
-  __DEVICE__ void HitCellMapping_d( Acc const& acc, Hit& hit, unsigned long t, Chain0_Args args ) {
+  __DEVICE__ void HitCellMapping_d( Acc const& acc, Hit& hit, unsigned long /*t*/, Chain0_Args args ) {
 #else
-  __DEVICE__ void HitCellMapping_d( Hit& hit, unsigned long t, Chain0_Args args ) {
+    __DEVICE__ void HitCellMapping_d( Hit& hit, unsigned long /*t*/, Chain0_Args args ) {
 #endif
 
     //    printf("start HCM_d %lu\n",t);

--- a/FastCaloSimAnalyzer/FastCaloGpu/src/GeoLoadGpu_al.cxx
+++ b/FastCaloSimAnalyzer/FastCaloGpu/src/GeoLoadGpu_al.cxx
@@ -47,7 +47,7 @@ struct TestHelloKernel
 struct TestCellKernel
 {
   template<typename TAcc>
-  ALPAKA_FN_ACC auto operator()(TAcc const& acc
+  ALPAKA_FN_ACC auto operator()(TAcc const& /*acc*/
 				, const CaloDetDescrElement* cells
 				, unsigned long index) const -> void
   {
@@ -70,11 +70,11 @@ struct TestCellKernel
 struct TestGeoKernel
 {
   template<typename TAcc>
-  ALPAKA_FN_ACC auto operator()(TAcc const& acc
+  ALPAKA_FN_ACC auto operator()(TAcc const& /*acc*/
 				, const CaloDetDescrElement* cells
 				, const GeoRegion* regions
-				, unsigned int nregions
-				, unsigned long ncells
+				, unsigned int /*nregions*/
+				, unsigned long /*ncells*/
 				, int r, int ir, int ip) const -> void
   {
     int                neta  = regions[r].cell_grid_eta();
@@ -121,7 +121,7 @@ struct TestGeoKernel
 struct TestGeoKernel_G
 {
   template<typename TAcc>
-  ALPAKA_FN_ACC auto operator()(TAcc const& acc
+  ALPAKA_FN_ACC auto operator()(TAcc const& /*acc*/
 				, const GeoGpu* geo
 				, int r, int ir, int ip) const -> void
   {

--- a/FastCaloSimAnalyzer/FastCaloGpu/src/GeoRegion.cxx
+++ b/FastCaloSimAnalyzer/FastCaloGpu/src/GeoRegion.cxx
@@ -40,10 +40,14 @@ __HOSTDEV__ float GeoRegion::calculate_distance_eta_phi( const long long DDE, fl
 #ifdef USE_STDPAR
   using std::max;
 #endif
+#ifdef USE_ALPAKA
+  using std::max;
+#endif
   dist_eta0           = ( eta - m_all_cells[DDE].eta() ) / m_deta_double;
   dist_phi0           = ( Phi_mpi_pi( phi - m_all_cells[DDE].phi() ) ) / m_dphi_double;
   float abs_dist_eta0 = abs( dist_eta0 );
   float abs_dist_phi0 = abs( dist_phi0 );
+
   return max( abs_dist_eta0, abs_dist_phi0 ) - 0.5;
 }
 


### PR DESCRIPTION
* `FastCaloSimAnalyzer/FastCaloGpu/src/CMakeLists.txt`
* `FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/HostDevDef.h`

A hack to prevent the exposure of alpaka definitions outside `FastCaloGpu` library via `HostDevDef.h`

* `FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/AlpakaDefs.h`

Fixed the definition of `FccDefaultAcc` for C++ threads and serial backends

* `FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/Rand4Hits.h`
* `FastCaloSimAnalyzer/FastCaloGpu/src/CaloGpuGeneral_al.cxx`
* `FastCaloSimAnalyzer/FastCaloGpu/src/CaloGpuGeneral_fnc.cxx`
* `FastCaloSimAnalyzer/FastCaloGpu/src/GeoLoadGpu_al.cxx`
* `FastCaloSimAnalyzer/FastCaloGpu/src/GeoRegion.cxx`

Fixed compiler issues uncovered when building for alpaka C++ threads backend